### PR TITLE
Fix unit tests

### DIFF
--- a/app/component/AboutPage.js
+++ b/app/component/AboutPage.js
@@ -20,9 +20,9 @@ const AboutPage = ({ currentLanguage }, { config }) => {
                 <h1 className="about-header">{section.header}</h1>
                 {section.paragraphs &&
                   section.paragraphs.map((p, j) => (
-                    <p key={`about-section-${i}-p-${j}`}>
+                    <section key={`about-section-${i}-p-${j}`}>
                       <SanitizedHTML allowedTags={allowedTags} html={p} />
-                    </p>
+                    </section>
                   ))}
                 {section.link && (
                   <a href={section.link}>

--- a/app/component/ItinerarySummaryListContainer.js
+++ b/app/component/ItinerarySummaryListContainer.js
@@ -54,6 +54,7 @@ function ItinerarySummaryListContainer(
         intermediatePlaces={intermediatePlaces}
         isCancelled={itineraryHasCancelation(itinerary)}
         showCancelled={showCancelled}
+        renderAlwaysNonTransitLegs
         zones={config.stopCard.header.showZone ? getZones(itinerary.legs) : []}
       >
         {i === openedIndex && children}

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -214,7 +214,14 @@ const isViaPointConnectingLeg = (leg, nextLeg, intermediatePlaces) => {
 };
 
 const SummaryRow = (
-  { data, breakpoint, intermediatePlaces, zones, renderAlwaysNonTransitLegs, ...props },
+  {
+    data,
+    breakpoint,
+    intermediatePlaces,
+    zones,
+    renderAlwaysNonTransitLegs,
+    ...props
+  },
   { intl, intl: { formatMessage }, config },
 ) => {
   const isTransitLeg = leg => leg.transitLeg || leg.rentedBike;

--- a/app/component/SummaryRow.js
+++ b/app/component/SummaryRow.js
@@ -214,7 +214,7 @@ const isViaPointConnectingLeg = (leg, nextLeg, intermediatePlaces) => {
 };
 
 const SummaryRow = (
-  { data, breakpoint, intermediatePlaces, zones, ...props },
+  { data, breakpoint, intermediatePlaces, zones, renderAlwaysNonTransitLegs, ...props },
   { intl, intl: { formatMessage }, config },
 ) => {
   const isTransitLeg = leg => leg.transitLeg || leg.rentedBike;
@@ -225,7 +225,6 @@ const SummaryRow = (
   const slackDuration = getTotalSlackDuration(intermediatePlaces);
   const legs = [];
   let noTransitLegs = true;
-  const renderAlwaysNonTransitLegs = true; // if true walking and bike renting will also be displayed
 
   if (!renderAlwaysNonTransitLegs) {
     data.legs.forEach(leg => {
@@ -500,11 +499,13 @@ SummaryRow.propTypes = {
   intermediatePlaces: PropTypes.array,
   isCancelled: PropTypes.bool,
   showCancelled: PropTypes.bool,
+  renderAlwaysNonTransitLegs: PropTypes.bool,
   zones: PropTypes.arrayOf(PropTypes.string),
 };
 
 SummaryRow.defaultProps = {
   zones: [],
+  renderAlwaysNonTransitLegs: false,
 };
 
 SummaryRow.contextTypes = {

--- a/test/unit/component/AboutPage.test.js
+++ b/test/unit/component/AboutPage.test.js
@@ -41,8 +41,8 @@ describe('<AboutPage />', () => {
       context,
       childContextTypes: { ...mockChildContextTypes },
     });
-    expect(wrapper.find('p').first().text()).to.equal('foo1'); //eslint-disable-line
-    expect(wrapper.find('p').last().text()).to.equal('foo2'); //eslint-disable-line
+    expect(wrapper.find('section').first().text()).to.equal('foo1'); //eslint-disable-line
+    expect(wrapper.find('section').last().text()).to.equal('foo2'); //eslint-disable-line
     expect(wrapper.find('.about-header').first().text()).to.equal('header1'); //eslint-disable-line
     expect(wrapper.find('.about-header').last().text()).to.equal('header2'); //eslint-disable-line
   });
@@ -61,6 +61,6 @@ describe('<AboutPage />', () => {
       childContextTypes: { ...mockChildContextTypes },
     });
     expect(wrapper.find('.about-header').first().text()).to.equal('sv_header1'); //eslint-disable-line
-    expect(wrapper.find('p').first().text()).to.equal('sv_foo1'); //eslint-disable-line
+    expect(wrapper.find('section').first().text()).to.equal('sv_foo1'); //eslint-disable-line
   });
 });

--- a/test/unit/component/DepartureCancelationInfo.test.js
+++ b/test/unit/component/DepartureCancelationInfo.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import React from 'react';
+import LocalTime from '../../../app/component/LocalTime';
 
 import { mountWithIntl } from '../helpers/mock-intl-enzyme';
 import DepartureCancelationInfo from '../../../app/component/DepartureCancelationInfo';
@@ -14,14 +15,22 @@ describe('<DepartureCancelationInfo />', () => {
     scheduledDepartureTime: 1547630218,
   };
 
+  // because the local time of the epoch second is different depending on your timezone, we have to localise it too
+  // before running the asserts
+  const localTimeInCurrentTimezone = LocalTime({
+    forceUtc: false,
+    time: defaultProps.scheduledDepartureTime,
+  });
+
   it('should render in English', () => {
     const wrapper = mountWithIntl(
       <DepartureCancelationInfo {...defaultProps} />,
       {},
       'en',
     );
+    expect(localTimeInCurrentTimezone).to.contain('16');
     expect(wrapper.text()).to.equal(
-      'Bus 52 Arabianranta–Munkkiniemi at 11:16 is cancelled',
+      `Bus 52 Arabianranta–Munkkiniemi at ${localTimeInCurrentTimezone} is cancelled`,
     );
   });
 
@@ -32,7 +41,7 @@ describe('<DepartureCancelationInfo />', () => {
       'fi',
     );
     expect(wrapper.text()).to.equal(
-      'Bussin 52 lähtö Arabianranta–Munkkiniemi kello 11:16 on peruttu',
+      `Bussin 52 lähtö Arabianranta–Munkkiniemi kello ${localTimeInCurrentTimezone} on peruttu`,
     );
   });
 
@@ -43,7 +52,7 @@ describe('<DepartureCancelationInfo />', () => {
       'sv',
     );
     expect(wrapper.text()).to.equal(
-      'Avgång på linje 52 Arabianranta–Munkkiniemi kl. 11:16 är inställd',
+      `Avgång på linje 52 Arabianranta–Munkkiniemi kl. ${localTimeInCurrentTimezone} är inställd`,
     );
   });
 });


### PR DESCRIPTION
Things i needed to fix:

- `DepartureCancelationTest`: different time zones led to a different result.
- `SummaryRow`: make `renderAlwaysNonTransitLegs` a prop and disable it by default
- `SanitizedHTML` introduced in https://github.com/mfdz/digitransit-ui/pull/39/commits/f7c5b32812c8a37ed0bfdeada66a358067442fb7 breaks a test by producing invalid HTML. i worked around it by replacing `<p>` with `<section>`. this might require a CSS tweak so the page looks as before.