### PR TITLE
include Matomo configuration

### DIFF
--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -39,6 +39,8 @@ export default configMerger(walttiConfig, {
   availableLanguages: ['de', 'en'],
   defaultLanguage: 'de',
 
+  MATOMO_URL: process.env.MATOMO_URL,
+
   appBarLink: {
     name: 'Feedback',
     href: 'https://mobil-in-herrenberg.de/feedback',

--- a/app/server.js
+++ b/app/server.js
@@ -284,7 +284,7 @@ export default function(req, res, next) {
 
     // Write preload hints before doing anything else
     if (process.env.NODE_ENV !== 'development') {
-      res.write(getAnalyticsInitCode(config.GTMid));
+      res.write(getAnalyticsInitCode(config.GTMid, config.MATOMO_URL));
 
       const preloads = [
         { as: 'style', href: config.URL.FONT },

--- a/app/util/analyticsUtils.js
+++ b/app/util/analyticsUtils.js
@@ -25,9 +25,20 @@ export function addAnalyticsEvent(event) {
  *
  * @param {number|string} GTMid Google Tag Manager id
  *
+ * @param MATOMO_URL
  * @return string
  */
-export function getAnalyticsInitCode(GTMid) {
+export function getAnalyticsInitCode(GTMid, MATOMO_URL) {
+  if (MATOMO_URL) {
+    return `<!-- Matomo Tag Manager -->
+      <script type="text/javascript">
+      var _mtm = _mtm || [];
+      _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.defer=true; g.src='${MATOMO_URL}'; s.parentNode.insertBefore(g,s);
+      </script>
+      <!-- End Matomo Tag Manager -->`;
+  }
   if (!GTMid) {
     return '';
   }


### PR DESCRIPTION
### The snippet
Use the snippet given by Matomo Tag Manager in the getAnalyticsInitCode function. It has an URL inside which should be configurable.

### The URL
Each config (which would like to use MTM) should include the MATOMO_URL environment variable.