### PR TITLE
Fix syntax error in attribution

### DIFF
--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -91,7 +91,7 @@ export default configMerger(walttiConfig, {
     key: MAP_KEY,
     tileSize: 256,
     zoomOffset: 0,
-    attribution: '&copy; <a tabindex=-1 href=http://osm.org/copyright>OpenStreetMap Mitwirkende</a>, <a tabindex=-1 href="https://www.maptiler.com/copyright/>© Maptiler</a>, <a tabindex=-1 href=https://www.nvbw.de/aufgaben/digitale-mobilitaet/open-data/>Datensätze der NVBW GmbH</a> und <a tabindex=-1 href=https://www.openvvs.de/dataset/gtfs-daten>VVS GmbH</a>'
+    attribution: '© <a tabindex=-1 href=http://osm.org/copyright>OpenStreetMap Mitwirkende</a>, © <a tabindex=-1 href="https://www.maptiler.com/copyright/">Maptiler</a>, <a tabindex=-1 href=https://www.nvbw.de/aufgaben/digitale-mobilitaet/open-data/>Datensätze der NVBW GmbH</a> und <a tabindex=-1 href=https://www.openvvs.de/dataset/gtfs-daten>VVS GmbH</a>'
   },
 
   feedIds: ['hb'],


### PR DESCRIPTION
There was a syntax error in the configuration string, that's why it showed up incorrectly.