### PR TITLE
Allow favourites to be opened even when no origin was entered

### DIFF
--- a/app/component/PanelOrSelectLocation.js
+++ b/app/component/PanelOrSelectLocation.js
@@ -3,9 +3,10 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import OriginSelector from './OriginSelector';
 import { dtLocationShape } from '../util/shapes';
+import { TAB_FAVOURITES } from '../util/path';
 
 const PanelOrSelectLocation = ({ panel, panelctx }) => {
-  if (panelctx.origin.ready) {
+  if (panelctx.origin.ready || panelctx.tab === TAB_FAVOURITES) {
     return React.createElement(panel, panelctx);
   }
 

--- a/app/util/path.js
+++ b/app/util/path.js
@@ -29,9 +29,9 @@ export const isEmpty = s =>
   s === undefined || s === null || s.trim() === '' || s.trim() === '-';
 
 export const getEndpointPath = (origin, destination, tab) => {
-  if (isEmpty(origin) && isEmpty(destination)) {
-    return '/';
-  }
+  // if (isEmpty(origin) && isEmpty(destination)) {
+  //   return '/';
+  // }
   return [
     '',
     encodeURIComponent(isEmpty(origin) ? '-' : origin),


### PR DESCRIPTION
This is a solution provided by Vlatko Vlahek via Slack.

It allows you to open the favourites panel when no origin has been selected. It looks like this:

![ezgif-6-e103a1b3deb8](https://user-images.githubusercontent.com/151346/74325898-b9209500-4d89-11ea-87be-a82a940844d2.gif)

Vlatko also provided another commit that allows you to jump back into the overview when clearing the search but I'm not sure if we need this feature. WDYT, Holger?