### PR TITLE
prefer cycleways WIP

### DIFF
--- a/app/configurations/config.hb.js
+++ b/app/configurations/config.hb.js
@@ -41,6 +41,10 @@ export default configMerger(walttiConfig, {
 
   MATOMO_URL: process.env.MATOMO_URL,
 
+  defaultSettings: {
+    optimize: "GREENWAYS",
+  },
+
   appBarLink: {
     name: 'Feedback',
     href: 'https://mobil-in-herrenberg.de/feedback',


### PR DESCRIPTION
## Goal:
 - **enable prefer by default when transport mode is set to bicycle**
 - **it must be variable by the user**
## Proposed Changes
 - now prefer cycleways are enabled by default (it is not a solution I only made this commit for the PR)

## Problems
 - once it is enabled can not be changed later 

## Files where possible configurations for the issue found
 - CustomizeSearchNew.js
 - queryUtils.js
 - RoutePreferencesSection.js
 - TransferOptionsSection.js

