### PR TITLE
Add URL to parking lot popup

### DIFF
--- a/app/component/map/popups/DynamicParkingLotsPopup.js
+++ b/app/component/map/popups/DynamicParkingLotsPopup.js
@@ -35,31 +35,61 @@ class DynamicParkingLotsPopup extends React.Component {
     lon: PropTypes.number.isRequired,
   };
 
-  getDesc() {
+  getCapacity() {
     const { intl } = this.context;
+    let text;
     if (this.props.feature.properties && this.props.feature.properties.free) {
-      return intl.formatMessage(
+      text = intl.formatMessage(
         {
           id: 'parking-spaces-available',
           defaultMessage: '{free} of {total} parking spaces available',
         },
         this.props.feature.properties,
       );
+    } else {
+      text = intl.formatMessage(
+        {
+          id: 'parking-spaces-in-total',
+          defaultMessage: 'Capacity: {total} parking spaces',
+        },
+        this.props.feature.properties,
+      );
     }
-    return intl.formatMessage(
-      {
-        id: 'parking-spaces-in-total',
-        defaultMessage: 'Capacity: {total} parking spaces',
-      },
-      this.props.feature.properties,
-    );
+
+    return <div className="padding-vertical-small">{text}</div>;
+  }
+
+  getUrl() {
+    const { intl } = this.context;
+    if (this.props.feature.properties && this.props.feature.properties.url) {
+      return (
+        <div className="padding-vertical-small">
+          <a
+            href={this.props.feature.properties.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {intl.formatMessage({
+              id: 'extra-info',
+              defaultMessage: 'More information',
+            })}
+          </a>
+        </div>
+      );
+    }
+    return null;
   }
 
   render() {
-    const desc = this.getDesc();
+    const desc = (
+      <div>
+        {this.getCapacity()}
+        {this.getUrl()}
+      </div>
+    );
     return (
       <Card>
-        <div className="padding-small">
+        <div className="padding-normal">
           <CardHeader
             name={this.props.feature.properties.name}
             description={desc}


### PR DESCRIPTION
This adds links to a page on herrenberg.de or stadtwerke.herrenberg.de to the parking layer popup.

### Screenshot
![Screenshot from 2020-02-27 14-45-02](https://user-images.githubusercontent.com/151346/75450819-c6d04000-596f-11ea-9574-eb34a318ad63.png)

### Video
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/151346/75451026-1c0c5180-5970-11ea-99a3-9711b089a9d5.gif)

Solves part of #71 

/cc @hbruch 