### PR TITLE
Take multiple icons on the same place into account

### DIFF
--- a/app/component/map/tile-layer/TileLayerContainer.js
+++ b/app/component/map/tile-layer/TileLayerContainer.js
@@ -217,7 +217,7 @@ class TileLayerContainer extends GridLayer {
     );
 
     if (typeof this.state.selectableTargets !== 'undefined') {
-      if (this.state.selectableTargets.length === 1) {
+      if (this.state.selectableTargets.length >= 1) {
         let id;
         if (this.state.selectableTargets[0].layer === 'stop') {
           id = this.state.selectableTargets[0].feature.properties.gtfsId;


### PR DESCRIPTION
The roadworks layer seems to exhibit a particularity that other layers don't: it draws two clickable areas for a single issue that lies on a tile border. This is presumably one feature for each tile.

When you click this roadworks sign, then there would be two clickable candidates and the click handler code was hard-wired to check if there is only a single one.

The fix was to also handle clicks when there are more than one target and select the first one.

This fixes the problem reported in #69 but I'm not sure if it opens the door to other problems, so lets test this thoroughly.

Fixes #69