### PR TITLE
Husky lint-translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && git-precommit-checks",
+      "pre-commit": "lint-staged && yarn lint-translations && git-precommit-checks",
       "pre-push": "npm run test-unit"
     }
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "digitransit-util/packages/*"
   ],
   "scripts": {
-    "static": "mkdir -p _static/js; mkdir -p _static/css; cp -r static/* _static",
+    "static": "mkdir -p _static/js; mkdir -p _static/css; cp -r static/* _static && yarn lint-translations",
     "win-static": "xcopy static\\* _static /e /s /y /i& if not exist _static\\js mkdir _static\\js& if not exist _static\\css mkdir _static\\css",
     "prebuild": "yarn run static",
     "predev": "yarn run static",


### PR DESCRIPTION
## Proposed Changes
 - added `lint-translations` to pre-commit hook
 - added `lint-translations` to `static run` script to increase the chance of running jsonlint 

## pre-commit hook
 - when you commit unsorted json files `jsonlint` sorts it after the successful commit so you will have "uncommitted files" (= sorted json files)

closes #190 