### PR TITLE
fix grey carpool icon

### DIFF
--- a/app/component/util.scss
+++ b/app/component/util.scss
@@ -239,7 +239,8 @@ $btn-heigth: 17px;
   &.subway,
   &.ferry,
   &.airplane,
-  &.citybike {
+  &.citybike,
+  &.carpool {
     .icon {
       color: $btn-icon-color-active;
     }


### PR DESCRIPTION
## Proposed Changes
 - make carpool icon white when enabled

![image](https://user-images.githubusercontent.com/54352878/82210168-d035cc80-990e-11ea-815d-60ec091c5948.png)
![image](https://user-images.githubusercontent.com/54352878/82210172-d330bd00-990e-11ea-938d-fdf66c4faf04.png)
